### PR TITLE
Add documentation and specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,90 @@
 # Aspire.Hosting.WebhookTester
-Aspire Hosting package for webhook testing
 
-This repository contains a sample Aspire app and unit tests.
-Functional tests under `sample/tests` require Docker.
+**Webhook Tester** is a small [Aspire](https://github.com/dotnet/aspire) extension that deploys the [`tarampampam/webhook-tester`](https://hub.docker.com/r/tarampampam/webhook-tester) container. It provides a simple way to inspect HTTP requests from your application while running locally.
+
+This repository contains the extension library, a sample app that shows how to use it and a small test suite.
+
+## Installation
+
+Add the NuGet package to your AppHost project:
+
+```bash
+dotnet add package Powell.Aspire.Hosting.WebhookTester
+```
+
+The extension targets **.NET 9** and ships as a regular NuGet package, so no additional tooling is required.
+
+## Basic usage
+
+Create a distributed application and add the webhook tester container:
+
+```csharp
+var builder = DistributedApplication.CreateBuilder(args);
+
+var webhook = builder.AddWebhookTester("webhook-tester")
+                     .WithLogLevel(LogLevel.Debug);
+
+var api = builder.AddProject<Projects.Api>("api")
+                 .WithReference(webhook)
+                 .WithDefaultWebhookToken(webhook);
+
+builder.Build().Run();
+```
+
+Calling `AddWebhookTester` registers the container and exposes two URLs (HTTP/HTTPS) ending with `/s/{token}` for the Web UI. The connection string for other services is `http://{host}:{port}/{token}` and can be retrieved via `GetConnectionString("webhook-tester")`.
+
+## Extension methods
+
+`WebhookTesterResourceBuilderExtensions` exposes a rich set of configuration helpers. Each method sets an environment variable understood by the container:
+
+| Method | Environment variable | Description |
+|-------|---------------------|-------------|
+| `WithHttpPort(int)` | `HTTP_PORT` | Override the listening port (defaults to 8080). |
+| `WithAutoCreateSessions(bool)` | `AUTO_CREATE_SESSIONS` | Automatically create an initial session. |
+| `WithLogLevel(LogLevel)` | `LOG_LEVEL` | Logging level (`debug`, `info`, `warn`, `error`). |
+| `WithLogFormat(LogFormat)` | `LOG_FORMAT` | Log output format (`text` or `json`). |
+| `WithServerAddress(string)` | `SERVER_ADDR` | Custom listen address. |
+| `WithHttpReadTimeout(TimeSpan)` | `HTTP_READ_TIMEOUT` | HTTP server read timeout. |
+| `WithHttpWriteTimeout(TimeSpan)` | `HTTP_WRITE_TIMEOUT` | HTTP server write timeout. |
+| `WithHttpIdleTimeout(TimeSpan)` | `HTTP_IDLE_TIMEOUT` | HTTP server idle timeout. |
+| `WithShutdownTimeout(TimeSpan)` | `SHUTDOWN_TIMEOUT` | Graceful shutdown timeout. |
+| `WithStorageDriver(StorageDriver)` | `STORAGE_DRIVER` | Storage backend (`memory` or `disk`). |
+| `WithFsStorageDir(string)` | `FS_STORAGE_DIR` | Directory for disk storage. |
+| `WithPubSubDriver(PubSubDriver)` | `PUBSUB_DRIVER` | Pub/Sub backend (`memory` or `redis`). |
+| `WithRedisDsn(string)` | `REDIS_DSN` | Redis connection string when using the Redis pub/sub driver. |
+| `WithTunnelDriver(TunnelDriver)` | `TUNNEL_DRIVER` | Tunnel provider (`ngrok`). |
+| `WithNgrokAuthToken(string)` | `NGROK_AUTHTOKEN` | ngrok authentication token. |
+| `WithSessionTtl(TimeSpan)` | `SESSION_TTL` | Session expiration duration. |
+| `WithMaxRequests(uint)` | `MAX_REQUESTS` | Maximum number of requests per session. |
+| `WithMaxRequestBodySize(uint)` | `MAX_REQUEST_BODY_SIZE` | Limit request payload size in bytes. |
+| `WithDefaultWebhookToken<T>` | `DEFAULT_SESSION_TOKEN` | Injects the default token into another resource. |
+
+`AddWebhookTester` itself sets `DEFAULT_SESSION_TOKEN` (always), `AUTO_CREATE_SESSIONS` (when enabled) and `HTTP_PORT` (when a custom port is provided).
+
+## Sample application
+
+The `sample` directory contains a minimal Aspire solution:
+
+- **AppHost** – registers the webhook tester and an API project.
+- **Api** – exposes a `/test` endpoint which posts data to the tester.
+- **ServiceDefaults** – shared hosting configuration used by the API.
+
+Run it with:
+
+```bash
+dotnet run --project sample/AppHost
+```
+
+During startup the AppHost prints the generated webhook URL. Sending a POST request to `Api` will forward it to the tester. You can then browse to the tester's Web UI at `/s/{token}` to inspect captured requests.
+
+## Tests
+
+The `tests` folder contains unit tests for the builder API. Integration tests that spin up containers require Docker and are located under `sample/SampleTests`. When running locally you can execute just the builder tests:
+
+```bash
+dotnet test tests/Aspire.Hosting.WebhookTester.Tests --filter FullyQualifiedName~WebhookTesterPublicApiTests
+```
+
+## License
+
+This project is licensed under the MIT license. See the [LICENSE](LICENSE) file for details.

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -1,0 +1,120 @@
+# WebhookTester Aspire Extension Specification
+
+This document reverse engineers the behaviour of the `Powell.Aspire.Hosting.WebhookTester` package. It can be used as a specification for implementing a compatible extension from scratch.
+
+## Project structure
+
+* Target framework: **.NET&nbsp;9**
+* Package ID: `Powell.Aspire.Hosting.WebhookTester`
+* Contains a single class library with file-scoped namespaces and implicit `using` directives.
+* Public APIs are defined inside the `Aspire.Hosting` namespace.
+
+## Container image
+
+The extension launches the [tarampampam/webhook-tester](https://hub.docker.com/r/tarampampam/webhook-tester) container:
+
+```csharp
+internal static class WebhookTesterContainerImageTags
+{
+    public const string Registry = "ghcr.io";
+    public const string Image = "tarampampam/webhook-tester";
+    public const string Tag = "2"; // or a specific version
+}
+```
+
+## Resource implementation
+
+`WebhookTesterResource` derives from `ContainerResource` and implements `IResourceWithConnectionString` and `IResourceWithServiceDiscovery`.
+
+```csharp
+public sealed class WebhookTesterResource : ContainerResource,
+    IResourceWithConnectionString, IResourceWithServiceDiscovery
+```
+
+Constructor parameters:
+
+```csharp
+WebhookTesterResource(string name, string defaultSessionToken)
+```
+
+* Stores `DefaultSessionToken`.
+* `PrimaryEndpoint` is lazily created with name `"http"`.
+* `EnvironmentVariables` exposes `{ "DEFAULT_SESSION_TOKEN", DefaultSessionToken }` for injection into other projects.
+* `ConnectionStringExpression` builds `http://{host}:{port}/{token}` from the primary endpoint and `DefaultSessionToken`.
+
+`GetConnectionStringAsync` honours `ConnectionStringRedirectAnnotation` if present.
+
+## Builder extensions
+
+The static class `WebhookTesterResourceBuilderExtensions` defines the fluent API. Important points:
+
+### AddWebhookTester
+
+```csharp
+IResourceBuilder<WebhookTesterResource> AddWebhookTester(
+    this IDistributedApplicationBuilder builder,
+    string name,
+    string? token = null,
+    bool autoCreateSessions = true,
+    int? port = null)
+```
+
+* Throws `ArgumentNullException` when `builder` or `name` are null.
+* When `token` is `null`, a new GUID is generated.
+* Registers a `WebhookTesterResource` and sets the container image based on `WebhookTesterContainerImageTags`.
+* Exposes an HTTP endpoint on `port` (defaults to **8080** inside the container).
+* Adds a health check on `/healthz`.
+* Sets environment variables:
+  * `DEFAULT_SESSION_TOKEN` – always present with the chosen token.
+  * `HTTP_PORT` – only when a custom port was provided.
+  * `AUTO_CREATE_SESSIONS` – when `autoCreateSessions` is `true`.
+* Adds UI links for the HTTP and HTTPS endpoints with path `/s/{token}`.
+
+### Configuration helpers
+
+Each helper validates its parameters and then calls `WithEnvironment` on the underlying `IResourceBuilder<WebhookTesterResource>`:
+
+* `WithHttpPort(int)` → `HTTP_PORT`
+* `WithAutoCreateSessions(bool)` → `AUTO_CREATE_SESSIONS`
+* `WithLogLevel(LogLevel)` → `LOG_LEVEL`
+* `WithLogFormat(LogFormat)` → `LOG_FORMAT`
+* `WithServerAddress(string)` → `SERVER_ADDR`
+* `WithHttpReadTimeout(TimeSpan)` → `HTTP_READ_TIMEOUT` (`15s`, `1500ms` etc.)
+* `WithHttpWriteTimeout(TimeSpan)` → `HTTP_WRITE_TIMEOUT`
+* `WithHttpIdleTimeout(TimeSpan)` → `HTTP_IDLE_TIMEOUT`
+* `WithShutdownTimeout(TimeSpan)` → `SHUTDOWN_TIMEOUT`
+* `WithStorageDriver(StorageDriver)` → `STORAGE_DRIVER`
+* `WithFsStorageDir(string)` → `FS_STORAGE_DIR`
+* `WithPubSubDriver(PubSubDriver)` → `PUBSUB_DRIVER`
+* `WithTunnelDriver(TunnelDriver)` → `TUNNEL_DRIVER` (only value is `ngrok`)
+* `WithNgrokAuthToken(string)` → `NGROK_AUTHTOKEN`
+* `WithRedisDsn(string)` → `REDIS_DSN` – validates the URI scheme is `redis` or `unix`.
+* `WithSessionTtl(TimeSpan)` → `SESSION_TTL`
+* `WithMaxRequests(uint)` → `MAX_REQUESTS`
+* `WithMaxRequestBodySize(uint)` → `MAX_REQUEST_BODY_SIZE`
+
+### WithDefaultWebhookToken
+
+```csharp
+IResourceBuilder<T> WithDefaultWebhookToken<T>(
+    this IResourceBuilder<T> builder,
+    IResourceBuilder<WebhookTesterResource> webhook)
+    where T : IResourceWithEnvironment
+```
+
+Copies `DEFAULT_SESSION_TOKEN` from the webhook tester resource into the consuming resource's environment variables.
+
+## Enumerations
+
+The API exposes several enums used by the configuration helpers:
+
+* `StorageDriver` – `Memory`, `Disk`
+* `PubSubDriver` – `Memory`, `Redis`
+* `TunnelDriver` – `Ngrok`
+* `LogLevel` – `Debug`, `Info`, `Warn`, `Error`
+* `LogFormat` – `Text`, `Json`
+
+## Expected behaviour
+
+An agent implementing this specification should produce an extension whose public surface matches the APIs above and that sets the correct environment variables when used in an Aspire AppHost project. Unit tests similar to those under `tests/Aspire.Hosting.WebhookTester.Tests` should pass against the implementation.
+


### PR DESCRIPTION
## Summary
- rewrite the README with install, usage and feature docs
- add a SPECIFICATION.md describing the extension

## Testing
- `dotnet test tests/Aspire.Hosting.WebhookTester.Tests/Aspire.Hosting.WebhookTester.Tests.csproj --no-build --filter "FullyQualifiedName~WebhookTesterPublicApiTests"`

------
https://chatgpt.com/codex/tasks/task_e_68797e0ec170832b8717801de6fcb615