### PR TITLE
chore: rename package to Allesa prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository contains the extension library, a sample app that shows how to u
 Add the NuGet package to your AppHost project:
 
 ```bash
-dotnet add package Powell.Aspire.Hosting.WebhookTester
+dotnet add package Allesa.Aspire.Hosting.WebhookTester
 ```
 
 The extension targets **.NET 9** and ships as a regular NuGet package, so no additional tooling is required.

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -1,11 +1,11 @@
 # WebhookTester Aspire Extension Specification
 
-This document specifiess the behaviour of the `Powell.Aspire.Hosting.WebhookTester` package. It can be used as a specification for implementing a compatible extension from scratch.
+This document specifiess the behaviour of the `Allesa.Aspire.Hosting.WebhookTester` package. It can be used as a specification for implementing a compatible extension from scratch.
 
 ## Project structure
 
 * Target framework: **.NET&nbsp;9**
-* Package ID: `Powell.Aspire.Hosting.WebhookTester`
+* Package ID: `Allesa.Aspire.Hosting.WebhookTester`
 * Contains a single class library with file-scoped namespaces and implicit `using` directives.
 * Public APIs are defined inside the `Aspire.Hosting` namespace.
 

--- a/src/Aspire.Hosting.WebhookTester/Aspire.Hosting.WebhookTester.csproj
+++ b/src/Aspire.Hosting.WebhookTester/Aspire.Hosting.WebhookTester.csproj
@@ -5,7 +5,7 @@
         <Nullable>enable</Nullable>
         <IsPackable>true</IsPackable>
         <EnablePackageValidation>true</EnablePackageValidation>
-        <PackageId>Powell.Aspire.Hosting.WebhookTester</PackageId>
+        <PackageId>Allesa.Aspire.Hosting.WebhookTester</PackageId>
         <PackageVersion>0.1.0</PackageVersion>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageReadmeFile>README.md</PackageReadmeFile>


### PR DESCRIPTION
## Summary
- use Allesa.Aspire.Hosting.WebhookTester as package ID
- update docs to reference the new prefix

## Testing
- `dotnet build -clp:Summary`
- `dotnet test tests/Aspire.Hosting.WebhookTester.Tests --filter FullyQualifiedName~WebhookTesterPublicApiTests`


------
https://chatgpt.com/codex/tasks/task_e_68c551ce7998832b989e9931eff4e078