### PR TITLE
fix: update release drafter name

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,4 +1,4 @@
-name-template: "Aspire.Hosting.Mailpit $RESOLVED_VERSION"
+name-template: "Aspire.Hosting.WebhookTester $RESOLVED_VERSION"
 tag-template: "$RESOLVED_VERSION"
 change-template: "- $TITLE by @$AUTHOR (#$NUMBER)"
 no-changes-template: "- No changes"


### PR DESCRIPTION
## Summary
- fix release drafter name

## Testing
- `dotnet test tests/Aspire.Hosting.WebhookTester.Tests --filter FullyQualifiedName~WebhookTesterPublicApiTests`


------
https://chatgpt.com/codex/tasks/task_e_68c5551ad7d8832ba7a4d9e03c19ff6a